### PR TITLE
Allow to select sprint using URL fragment, show sprint description when one is selected

### DIFF
--- a/content/js/programme.js
+++ b/content/js/programme.js
@@ -291,6 +291,8 @@
         if (eventElem) {
           eventElem.scrollIntoView();
         }
+      } else {
+        showSprintDescription();
       }
     }
   }
@@ -347,8 +349,21 @@
     modal.modal('show')
   }
 
+  function showSprintDescription() {
+    // Show description if hash is a sprint identifier
+    var sprint = $(window.location.hash + '-desc.collapse');
+    if (sprint.length !== 0) {
+      sprint.collapse('show');
+      $(window.location.hash)[0].scrollIntoView();
+    }
+  }
+
   function init() {
     fetchProgram(createProgramTables)
   }
+
+  $(window).bind('hashchange', function() {
+    showSprintDescription();
+  });
 
 })(window, window.moment)

--- a/content/pages/programme.html
+++ b/content/pages/programme.html
@@ -95,14 +95,14 @@
   </div>
 
   <div class="panel panel-default">
-    <div class="panel-heading" role="tab" id="headingOne">
+    <div id="anyblok" class="panel-heading" role="tab">
       <h3 class="panel-title">
-        <a role="button" data-toggle="collapse" href="#anyblock" aria-expanded="true" aria-controls="anyblock">
+        <a role="button" data-toggle="collapse" data-target="#anyblok-desc" aria-expanded="false" aria-controls="anyblok-desc">
           Ajouter de nouveaux comportements techniques et / ou fonctionnels à AnyBlok
         </a>
       </h3>
     </div>
-    <div id="anyblock" class="panel-collapse collapse">
+    <div id="anyblok-desc" class="panel-collapse collapse">
       <div class="panel-body">
         <p>Présentation d'AnyBlok et des composant existant. Présentation des ajouts ou modifications envisagés :</p>
         <ul>
@@ -116,12 +116,12 @@
     </div>
   </div>
   <div class="panel panel-default">
-    <div class="panel-heading" role="tab">
+    <div id="ansible" class="panel-heading" role="tab">
       <h3 class="panel-title">
-        <a role="button" data-toggle="collapse" data-target="#ansible">Ansible modules: autumn cleaning</a>
+        <a role="button" data-toggle="collapse" data-target="#ansible-desc" aria-expanded="false" aria-controls="ansible-desc">Ansible modules: autumn cleaning</a>
       </h3>
     </div>
-    <div id="ansible" class="panel-collapse collapse">
+    <div id="ansible-desc" class="panel-collapse collapse">
       <div class="panel-body">
         <p>
           Au cours de ce sprint, avec l'aide d'un contributeur et d'un membre de la _core team_, nous vous proposons de contribuer à Ansible et plus particulièrement aux modules Ansible existants:
@@ -150,12 +150,12 @@
     </div>
   </div>
   <div class="panel panel-default">
-    <div class="panel-heading" role="tab">
+    <div id="modoboa" class="panel-heading" role="tab">
       <h3 class="panel-title">
-        <a role="button" data-toggle="collapse" data-target="#modoboa">Contribuer à Modoboa</a>
+        <a role="button" data-toggle="collapse" data-target="#modoboa-desc" aria-expanded="false" aria-controls="modoboa-desc">Contribuer à Modoboa</a>
       </h3>
     </div>
-    <div id="modoboa" class="panel-collapse collapse">
+    <div id="modoboa-desc" class="panel-collapse collapse">
       <div class="panel-body">
 
         <p>En plus de la chasse aux bogues, plusieurs sujets de fond sont en cours et mériteraient bien un coup de main :</p>
@@ -169,24 +169,24 @@
     </div>
   </div>
   <div class="panel panel-default">
-    <div class="panel-heading" role="tab">
+    <div id="docs-python" class="panel-heading" role="tab">
       <h3 class="panel-title">
-        <a role="button" data-toggle="collapse" data-target="#docs-python">docs.#docspython.org/fr: Traduisons tous la doc d'un module</a>
+        <a role="button" data-toggle="collapse" data-target="#docs-python-desc" aria-expanded="false" aria-controls="docs-python-desc">docs.#docspython.org/fr: Traduisons tous la doc d'un module</a>
       </h3>
     </div>
-    <div id="docs-python" class="panel-collapse collapse">
+    <div id="docs-python-desc" class="panel-collapse collapse">
       <div class="panel-body">
         <p>Découvrez un module Python en traduisant sa documentation, vous apprendrez probablement pas mal de chose tout en rendant Python plus accessible.</p>
       </div>
     </div>
   </div>
   <div class="panel panel-default">
-    <div class="panel-heading" role="tab">
+    <div id="gnocchi" class="panel-heading" role="tab">
       <h3 class="panel-title">
-        <a role="button" data-toggle="collapse" data-target="#gnocchi">Gnocchi, a distributed timeseries database</a>
+        <a role="button" data-toggle="collapse" data-target="#gnocchi-desc" aria-expanded="false" aria-controls="gnocchi-desc">Gnocchi, a distributed timeseries database</a>
       </h3>
     </div>
-    <div id="gnocchi" class="panel-collapse collapse">
+    <div id="gnocchi-desc" class="panel-collapse collapse">
       <div class="panel-body">
         <p>Gnocchi is a distributed timeseries database written in Python. It offers a scalable REST API to interact with.<br>
           It leverages many Python good practice and its architecture is entirely done in scale-out fashion, making it interesting to study if you want to learn how build scalable applications with Python.
@@ -201,12 +201,12 @@
     </div>
   </div>
   <div class="panel panel-default">
-    <div class="panel-heading" role="tab">
+    <div id="ideascube" class="panel-heading" role="tab">
       <h3 class="panel-title">
-        <a role="button" data-toggle="collapse" data-target="#ideascube">Ideascube</a>
+        <a role="button" data-toggle="collapse" data-target="#ideascube-desc" aria-expanded="false" aria-controls="ideascube-desc">Ideascube</a>
       </h3>
     </div>
-    <div id="ideascube" class="panel-collapse collapse">
+    <div id="ideascube-desc" class="panel-collapse collapse">
       <div class="panel-body">
         <p>Ideascube est un logiciel libre embarqué dans les bibliothèques déployées par BSF à travers le monde. Il est à la fois une médiathèque, un moteur de blog, ainsi que l'interface de gestion du serveur.</p>
 
@@ -227,12 +227,12 @@
     </div>
   </div>
   <div class="panel panel-default">
-    <div class="panel-heading" role="tab">
+    <div id="tracim" class="panel-heading" role="tab">
       <h3 class="panel-title">
-        <a role="button" data-toggle="collapse" data-target="#tracim">Nouvelles fonctionnalités sur la plateforme collaborative tracim</a>
+        <a role="button" data-toggle="collapse" data-target="#tracim-desc" aria-expanded="false" aria-controls="tracim-desc">Nouvelles fonctionnalités sur la plateforme collaborative tracim</a>
       </h3>
     </div>
-    <div id="tracim" class="panel-collapse collapse">
+    <div id="tracim-desc" class="panel-collapse collapse">
       <div class="panel-body">
         <p>Tracim est un logiciel collaboratif développé en python, il propose des fonctionnalités de forum, wiki, gestion électronique de documents, calendriers partagés à travers une interface web. Tracim cible les professionnels, c'est un logiciel distribué sous licence AGPL et dont le code et le développement sont ouverts. Tout se passe sur Github :
           <a href="https://github.com/tracim/tracim">https://github.com/tracim/tracim</a>
@@ -250,12 +250,12 @@
     </div>
   </div>
   <div class="panel panel-default">
-    <div class="panel-heading" role="tab">
+    <div id="lem2" class="panel-heading" role="tab">
       <h3 class="panel-title">
-        <a role="button" data-toggle="collapse" data-target="#lem2">Optimizing LEM2 Algorithm (Rough Sets Theory)</a>
+        <a role="button" data-toggle="collapse" data-target="#lem2-desc" aria-expanded="false" aria-controls="lem2-desc">Optimizing LEM2 Algorithm (Rough Sets Theory)</a>
       </h3>
     </div>
-    <div id="lem2" class="panel-collapse collapse">
+    <div id="lem2-desc" class="panel-collapse collapse">
       <div class="panel-body">
         <p>The aim of The Rough Sets Theory is to classify and analyze imprecise and incomplete data. LEM2 is one of the most known algorithms relying on this approach. While LEM2 is efficient in terms of knowledge discovery (and more specifically in rule induction), its running time is still very large. The goal of this sprint is to implement and optimize this algorithm using pythonic means.</p>
 
@@ -275,12 +275,12 @@
     </div>
   </div>
   <div class="panel panel-default">
-    <div class="panel-heading" role="tab">
+    <div id="afpy" class="panel-heading" role="tab">
       <h3 class="panel-title">
-        <a role="button" data-toggle="collapse" data-target="#afpy">Site web et outils de communication de l'AFPy</a>
+        <a role="button" data-toggle="collapse" data-target="#afpy-desc" aria-expanded="false" aria-controls="afpy-desc">Site web et outils de communication de l'AFPy</a>
       </h3>
     </div>
-    <div id="afpy" class="panel-collapse collapse">
+    <div id="afpy-desc" class="panel-collapse collapse">
       <div class="panel-body">
         <p>Le site web de l'AFPy n'a pas évolué depuis plusieurs années, il est temps de se pencher sur la question !</p>
 
@@ -289,12 +289,12 @@
     </div>
   </div>
   <div class="panel panel-default">
-    <div class="panel-heading" role="tab">
+    <div id="plone" class="panel-heading" role="tab">
       <h3 class="panel-title">
-        <a role="button" data-toggle="collapse" data-target="#plone">Sprint Plone Frontend</a>
+        <a role="button" data-toggle="collapse" data-target="#plone-desc" aria-expanded="false" aria-controls="plone-desc">Sprint Plone Frontend</a>
       </h3>
     </div>
-    <div id="plone" class="panel-collapse collapse">
+    <div id="plone-desc" class="panel-collapse collapse">
       <div class="panel-body">
         <p>Plone évolue vers une solution purement backend exposant une API REST. En tant que CMS il doit tout de même présenter une UI riche.</p>
         <p>Deux approches sont actuellement en cours dans la communauté: React et Angular.</p>
@@ -303,12 +303,12 @@
     </div>
   </div>
   <div class="panel panel-default">
-    <div class="panel-heading" role="tab">
+    <div id="dace" class="panel-heading" role="tab">
       <h3 class="panel-title">
-        <a role="button" data-toggle="collapse" data-target="#dace">Utilisation de la bibliothèque DACE pour la réalisation d'une gestion de congés</a>
+        <a role="button" data-toggle="collapse" data-target="#dace-desc" aria-expanded="false" aria-controls="dace-desc">Utilisation de la bibliothèque DACE pour la réalisation d'une gestion de congés</a>
       </h3>
     </div>
-    <div id="dace" class="panel-collapse collapse">
+    <div id="dace-desc" class="panel-collapse collapse">
       <div class="panel-body">
         <p>Dace est une bibliothèque Python sous licence AGPL v3 permettant d'écrire des processus métier complexes.</p>
         <p>Elle est utilisée dans l'outil d'innovation participative Nova-Ideo.com et dans l'agenda d'événements culturels LAgendaCommun.org .</p>


### PR DESCRIPTION
Currently there are HTML id for every sprint but there are not usable: when https://www.pycon.fr/2017/programme.html#dace is used navigator doesn't scroll to `Utilisation de la bibliothèque DACE pour la réalisation d'une gestion de congés`.

This pull request allows to display sprint description when one is selected.