### PR TITLE
Informations sur les flux utilisables dans des applications dont Giggity

### DIFF
--- a/content/pages/programme.html
+++ b/content/pages/programme.html
@@ -84,6 +84,17 @@
     </div><!-- /.modal-dialog -->
   </div><!-- /.modal -->
 
+  <h3>Voir le programme sur mobile</h3>
+  <p>
+  Le programme est disponible sur un flux XML ou ics. Vous pouvez l'ajouter à un logiciel lourd ou une application mobile.
+    <ul>
+        <li>XML : <a href="https://cfp.pycon.fr/schedule/xml">https://cfp.pycon.fr/schedule/xml</a></li>
+        <li>ICS : <a href="https://cfp.pycon.fr/schedule/ics">https://cfp.pycon.fr/schedule/ics</a></li>
+    </ul>
+
+    Sur Android, vous pouvez utiliser Giggity qui est disponible sur <a href="https://f-droid.org/repository/browse/?fdid=net.gaast.giggity">F-Droid</a> et <a href="https://play.google.com/store/apps/details?id=net.gaast.giggity">Google Play Store</a>.
+  </p>
+
   <h2 id="sprints">Les Sprints: Jeudi 21 et Vendredi 22 Septembre</h2>
 
 


### PR DESCRIPTION
Cette pull-request ajoute un paragraphe indiquant l'usage du flux XML avec des applis qui peuvent le gérer.
cf. #7

On pourrait ajouter un QRCode pour faciliter l'usage mais comme il est possible que le flux soit directement intégré dans Giggity (cf.https://github.com/Wilm0r/giggity/pull/24), cela n'a peut-être pas d'intérêt.