### PR TITLE
navbar/sprints: add days, move and fix case

### DIFF
--- a/content/pages/programme.html
+++ b/content/pages/programme.html
@@ -16,12 +16,12 @@
 
   <ul class="nav nav-pills">
     <li role="presentation" class="active">
-      <a href="#day1">Conférences du Samedi 23</a></li>
-    <li role="presentation"><a href="#day2">Conférences du Dimanche 24</a></li>
+      <a href="#day1">Conférences du samedi 23</a></li>
+    <li role="presentation"><a href="#day2">Conférences du dimanche 24</a></li>
     <li role="presentation"><a href="#sprints">Sprints</a></li>
   </ul>
 
-  <h2>Les conférences, Samedi 23 et dimanche 24 septembre</h2>
+  <h2>Les conférences, samedi 23 et dimanche 24 septembre</h2>
 
   <div class="alert alert-info" role="alert">
     <p style="font-size: 170%;">
@@ -95,7 +95,7 @@
     Sur Android, vous pouvez utiliser Giggity qui est disponible sur <a href="https://f-droid.org/repository/browse/?fdid=net.gaast.giggity">F-Droid</a> et <a href="https://play.google.com/store/apps/details?id=net.gaast.giggity">Google Play Store</a>.
   </p>
 
-  <h2 id="sprints">Les Sprints: Jeudi 21 et Vendredi 22 Septembre</h2>
+  <h2 id="sprints">Les sprints: jeudi 21 et vendredi 22 septembre</h2>
 
 
   <div class="alert alert-info" role="alert">

--- a/content/pages/programme.html
+++ b/content/pages/programme.html
@@ -15,10 +15,10 @@
   <h1 class="catchline">Toulouse<br/>21-24 septembre 2017</h1>
 
   <ul class="nav nav-pills">
+    <li role="presentation"><a href="#sprints">Sprints: jeudi 21 et vendredi 22</a></li>
     <li role="presentation" class="active">
       <a href="#day1">Conférences du samedi 23</a></li>
     <li role="presentation"><a href="#day2">Conférences du dimanche 24</a></li>
-    <li role="presentation"><a href="#sprints">Sprints: jeudi 21 et vendredi 22</a></li>
   </ul>
 
   <h2>Les conférences, samedi 23 et dimanche 24 septembre</h2>

--- a/content/pages/programme.html
+++ b/content/pages/programme.html
@@ -18,7 +18,7 @@
     <li role="presentation" class="active">
       <a href="#day1">Conférences du samedi 23</a></li>
     <li role="presentation"><a href="#day2">Conférences du dimanche 24</a></li>
-    <li role="presentation"><a href="#sprints">Sprints</a></li>
+    <li role="presentation"><a href="#sprints">Sprints: jeudi 21 et vendredi 22</a></li>
   </ul>
 
   <h2>Les conférences, samedi 23 et dimanche 24 septembre</h2>


### PR DESCRIPTION
In `programme.html`:
- Top navbar:
  - move sprints at the beginning (sprints are first, Saturday still the default) 
  - sprints: add days (like other entries)
- Fix case